### PR TITLE
rbaumbach/simplify content overview

### DIFF
--- a/config/user.role.administrator.yml
+++ b/config/user.role.administrator.yml
@@ -20,6 +20,7 @@ dependencies:
     - locale
     - media
     - node
+    - override_node_options
     - paragraphs
     - replicate_ui
     - system
@@ -45,7 +46,6 @@ permissions:
   - 'bypass node access'
   - 'create achievement content'
   - 'create article content'
-  - 'create content translations'
   - 'create media'
   - 'create story content'
   - 'create terms in agency'
@@ -89,13 +89,15 @@ permissions:
   - 'edit terms in security_role_area'
   - 'edit terms in story_type'
   - 'edit terms in theme'
+  - 'enter article revision log entry'
+  - 'enter story revision log entry'
   - 'import needs and requirements figures'
+  - 'override article authored on option'
   - 'replicate entities'
   - 'revert achievement revisions'
   - 'revert all revisions'
   - 'revert article revisions'
   - 'revert story revisions'
-  - 'translate any entity'
   - 'translate interface'
   - 'update any media'
   - 'update content translations'

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -10,7 +10,6 @@ dependencies:
     - taxonomy.vocabulary.section
     - taxonomy.vocabulary.story_type
   module:
-    - content_translation
     - filter
     - gho_access
     - gho_fields
@@ -18,6 +17,7 @@ dependencies:
     - locale
     - media
     - node
+    - override_node_options
     - paragraphs
     - replicate_ui
     - system
@@ -40,7 +40,6 @@ permissions:
   - 'bypass node access'
   - 'create achievement content'
   - 'create article content'
-  - 'create content translations'
   - 'create media'
   - 'create story content'
   - 'create terms in section'
@@ -52,7 +51,6 @@ permissions:
   - 'delete any media'
   - 'delete any story content'
   - 'delete article revisions'
-  - 'delete content translations'
   - 'delete media'
   - 'delete own achievement content'
   - 'delete own article content'
@@ -69,16 +67,17 @@ permissions:
   - 'edit own story content'
   - 'edit terms in section'
   - 'edit terms in story_type'
+  - 'enter article revision log entry'
+  - 'enter story revision log entry'
   - 'import needs and requirements figures'
+  - 'override article authored on option'
   - 'replicate entities'
   - 'revert achievement revisions'
   - 'revert all revisions'
   - 'revert article revisions'
   - 'revert story revisions'
-  - 'translate any entity'
   - 'translate interface'
   - 'update any media'
-  - 'update content translations'
   - 'update media'
   - 'use text format filtered_html'
   - 'view achievement revisions'

--- a/config/views.view.content.yml
+++ b/config/views.view.content.yml
@@ -1089,8 +1089,8 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: gho_translation_links
-          label: English
-          exclude: false
+          label: French
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -1141,8 +1141,8 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: gho_translation_links
-          label: English
-          exclude: false
+          label: Spanish
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -1193,8 +1193,8 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: gho_translation_links
-          label: English
-          exclude: false
+          label: Arabic
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -1383,56 +1383,6 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
-        langcode:
-          id: langcode
-          table: node_field_data
-          field: langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: langcode
-          plugin_id: language
-          operator: in
-          value:
-            en: en
-            fr: fr
-            es: es
-            ar: ar
-          group: 1
-          exposed: true
-          expose:
-            operator_id: langcode_op
-            label: Language
-            description: ''
-            use_operator: false
-            operator: langcode_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: langcode
-            required: true
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            reduce: true
-          is_grouped: false
-          group_info:
-            label: 'Translation language'
-            description: null
-            identifier: langcode
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1: {  }
-              2: {  }
-              3: {  }
       filter_groups:
         operator: AND
         groups:
@@ -1821,8 +1771,8 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: gho_translation_links
-          label: English
-          exclude: false
+          label: French
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -1873,8 +1823,8 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: gho_translation_links
-          label: English
-          exclude: false
+          label: Spanish
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -1925,8 +1875,8 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: gho_translation_links
-          label: English
-          exclude: false
+          label: Arabic
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -2099,7 +2049,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
+          reduce_duplicates: true
           vid: major_tags
           type: textfield
           hierarchy: false
@@ -2165,53 +2115,6 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
-        langcode:
-          id: langcode
-          table: node_field_data
-          field: langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: langcode
-          plugin_id: language
-          operator: in
-          value:
-            en: en
-            fr: fr
-            es: es
-            ar: ar
-          group: 1
-          exposed: true
-          expose:
-            operator_id: langcode_op
-            label: Language
-            description: ''
-            use_operator: false
-            operator: langcode_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: langcode
-            required: true
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            reduce: true
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -2599,8 +2502,8 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: gho_translation_links
-          label: English
-          exclude: false
+          label: French
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -2651,8 +2554,8 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: gho_translation_links
-          label: English
-          exclude: false
+          label: Spanish
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -2703,8 +2606,8 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: gho_translation_links
-          label: English
-          exclude: false
+          label: Arabic
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -2831,7 +2734,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
+          reduce_duplicates: true
           vid: major_tags
           type: textfield
           hierarchy: false
@@ -2988,53 +2891,6 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
-        langcode:
-          id: langcode
-          table: node_field_data
-          field: langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: langcode
-          plugin_id: language
-          operator: in
-          value:
-            en: en
-            fr: fr
-            es: es
-            ar: ar
-          group: 1
-          exposed: true
-          expose:
-            operator_id: langcode_op
-            label: Language
-            description: ''
-            use_operator: false
-            operator: langcode_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: langcode
-            required: true
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            reduce: true
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -3359,8 +3215,8 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: gho_translation_links
-          label: English
-          exclude: false
+          label: French
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -3411,8 +3267,8 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: gho_translation_links
-          label: English
-          exclude: false
+          label: Spanish
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -3463,8 +3319,8 @@ display:
           admin_label: ''
           entity_type: node
           plugin_id: gho_translation_links
-          label: English
-          exclude: false
+          label: Arabic
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -3700,56 +3556,6 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
-        langcode:
-          id: langcode
-          table: node_field_data
-          field: langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: langcode
-          plugin_id: language
-          operator: in
-          value:
-            en: en
-            fr: fr
-            es: es
-            ar: ar
-          group: 1
-          exposed: true
-          expose:
-            operator_id: langcode_op
-            label: Language
-            description: ''
-            use_operator: false
-            operator: langcode_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: langcode
-            required: true
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            reduce: true
-          is_grouped: false
-          group_info:
-            label: 'Translation language'
-            description: null
-            identifier: langcode
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1: {  }
-              2: {  }
-              3: {  }
       filter_groups:
         operator: AND
         groups:

--- a/html/modules/custom/gho_fields/src/Plugin/views/field/GhoTranslationLinks.php
+++ b/html/modules/custom/gho_fields/src/Plugin/views/field/GhoTranslationLinks.php
@@ -96,7 +96,6 @@ class GhoTranslationLinks extends LinkBase {
 
     $language = $this->languageManager->getLanguage($this->options['langcode']);
     $url->setOption('language', $language);
-    $url->setOption('query', $this->destination->getAsArray());
 
     if ($url->access()) {
       return [


### PR DESCRIPTION
- Make the delete translation form action work again
- Hide translation links from content overview and node edit screens, remove duplicates from content overview when filtering by tags
