### PR TITLE
release versions/v3.2.6

### DIFF
--- a/config/core.entity_form_display.node.article.default.yml
+++ b/config/core.entity_form_display.node.article.default.yml
@@ -33,7 +33,7 @@ third_party_settings:
       children:
         - field_hero_image
         - field_caption
-      label: Image
+      label: 'Hero image'
       region: content
       parent_name: group_tabs
       weight: 24
@@ -45,8 +45,6 @@ third_party_settings:
         formatter: closed
         description: ''
         required_fields: true
-        direction: horizontal
-        width_breakpoint: 640
     group_meta_data:
       children:
         - field_article_type
@@ -133,6 +131,7 @@ content:
       collapsible: false
       collapsed: true
       revision: false
+      removed_reference: optional
     third_party_settings: {  }
   field_caption:
     type: double_field

--- a/config/core.entity_view_display.media.image.full_width.yml
+++ b/config/core.entity_view_display.media.image.full_width.yml
@@ -1,6 +1,6 @@
 uuid: f76568cd-3529-4602-9b17-33e4c6e04447
 langcode: en
-status: false
+status: true
 dependencies:
   config:
     - core.entity_view_mode.media.full_width

--- a/config/core.entity_view_display.paragraph.image_with_text.default.yml
+++ b/config/core.entity_view_display.paragraph.image_with_text.default.yml
@@ -17,16 +17,16 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: thumbnail_medium
+      view_mode: full_width
       link: false
     third_party_settings: {  }
-    weight: 2
+    weight: 0
     region: content
   field_text:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 3
+    weight: 1
     region: content
 hidden: {  }

--- a/config/field.field.node.article.field_caption.yml
+++ b/config/field.field.node.article.field_caption.yml
@@ -12,14 +12,14 @@ field_name: field_caption
 entity_type: node
 bundle: article
 label: Caption
-description: 'Caption that will be displayed below the title. It is composed of 2 elements that need to be specified separately in the 2 fields above, the <strong>location</strong> in the form <em>Location, Country</em>. Ex: <em>Mbuji-Mayi, RDC</em> and a <strong>text</strong>. Credits for the hero image will be automatically added to the end when displayed.'
+description: 'When this image is used on Humanitarian Action, it will include a written text comprising the <strong>location</strong> in bold, followed by the <strong>caption</strong>, and then the <strong>image credits</strong>. These credits are defined in the Media Library and not editable here.'
 required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
   first:
-    label: Location
+    label: 'Image location'
     list: false
     allowed_values: {  }
     max: null
@@ -28,7 +28,7 @@ settings:
     on_label: 'On'
     off_label: 'Off'
   second:
-    label: Text
+    label: Caption
     list: false
     allowed_values: {  }
     max: null

--- a/config/field.field.node.article.field_hero_image.yml
+++ b/config/field.field.node.article.field_hero_image.yml
@@ -10,7 +10,7 @@ id: node.article.field_hero_image
 field_name: field_hero_image
 entity_type: node
 bundle: article
-label: 'Main article image'
+label: 'Hero image'
 description: 'Large image displayed at the top of the article''s page and used as a thumbnail image in article teasers.'
 required: false
 translatable: true

--- a/config/field.field.node.article.field_paragraphs.yml
+++ b/config/field.field.node.article.field_paragraphs.yml
@@ -6,7 +6,6 @@ dependencies:
     - field.storage.node.field_paragraphs
     - node.type.article
     - paragraphs.paragraphs_type.achievement
-    - paragraphs.paragraphs_type.image_with_text
   module:
     - entity_reference_revisions
 id: node.article.field_paragraphs
@@ -23,7 +22,6 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      image_with_text: image_with_text
       achievement: achievement
     negate: 1
     target_bundles_drag_drop:
@@ -42,6 +40,12 @@ settings:
       bottom_figure_row:
         weight: 8
         enabled: false
+      document_articles:
+        weight: 28
+        enabled: false
+      document_chapter:
+        weight: 29
+        enabled: false
       download_button:
         weight: 26
         enabled: false
@@ -56,7 +60,7 @@ settings:
         enabled: false
       image_with_text:
         weight: 12
-        enabled: true
+        enabled: false
       interactive_content:
         weight: 31
         enabled: false

--- a/config/paragraphs.paragraphs_type.image_with_text.yml
+++ b/config/paragraphs.paragraphs_type.image_with_text.yml
@@ -1,31 +1,10 @@
 uuid: ddf7ec8a-7a21-47c0-870f-6b9a1344099e
 langcode: en
 status: true
-dependencies:
-  module:
-    - paragraphs_viewmode
+dependencies: {  }
 id: image_with_text
 label: 'Image with text'
 icon_uuid: null
 icon_default: null
 description: 'An image with a text.'
-behavior_plugins:
-  paragraphs_viewmode_behavior:
-    enabled: true
-    override_mode: third_width_cropped
-    override_available:
-      third_width_cropped: third_width_cropped
-      default: '0'
-      full_width: '0'
-      half_width: '0'
-      hero_image: '0'
-      link_with_background_image_medium: '0'
-      link_with_background_image_small: '0'
-      linked_image_medium: '0'
-      linked_image_small: '0'
-      preview: '0'
-      single_column: '0'
-      third_width: '0'
-      three_columns: '0'
-      two_columns: '0'
-    override_default: third_width_cropped
+behavior_plugins: {  }

--- a/html/modules/custom/ncms_ui/css/article_edit_form.css
+++ b/html/modules/custom/ncms_ui/css/article_edit_form.css
@@ -1,0 +1,13 @@
+form.node-article-form fieldset[data-drupal-selector="edit-field-hero-image"],
+form.node-article-edit-form fieldset[data-drupal-selector="edit-field-hero-image"] {
+  padding: 0;
+  border: 0;
+}
+form.node-article-form fieldset[data-drupal-selector="edit-field-hero-image"] legend,
+form.node-article-edit-form fieldset[data-drupal-selector="edit-field-hero-image"] legend {
+  display: none;
+}
+form.node-article-form fieldset[data-drupal-selector="edit-field-hero-image"] .fieldset__wrapper,
+form.node-article-edit-form fieldset[data-drupal-selector="edit-field-hero-image"] .fieldset__wrapper {
+  margin: 0;
+}

--- a/html/modules/custom/ncms_ui/ncms_ui.libraries.yml
+++ b/html/modules/custom/ncms_ui/ncms_ui.libraries.yml
@@ -17,6 +17,10 @@ layout_paragraphs:
   css:
     component:
       css/layout_paragraphs.css: {}
+article_edit_form:
+  css:
+    component:
+      css/article_edit_form.css: {}
 document_edit_form:
   css:
     component:

--- a/html/modules/custom/ncms_ui/ncms_ui.module
+++ b/html/modules/custom/ncms_ui/ncms_ui.module
@@ -183,7 +183,15 @@ function ncms_ui_form_node_form_alter(&$form, FormStateInterface $form_state) {
   ];
 
   if ($node instanceof Document) {
+    // Attach custom styles.
     $form['#attached']['library'][] = 'ncms_ui/document_edit_form';
+  }
+
+  if ($node instanceof Article) {
+    // Hide the label of the double field widget.
+    $form['field_caption']['widget'][0]['#title_display'] = FALSE;
+    // Attach custom styles.
+    $form['#attached']['library'][] = 'ncms_ui/article_edit_form';
   }
 
   /** @var \Drupal\ncms_ui\ContentManager $content_manager */

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -29,10 +29,20 @@ gho-hero-image:
     theme:
       components/gho-hero-image/gho-hero-image.css: {}
 
+gho-image-with-text:
+  css:
+    theme:
+      components/gho-image-with-text/gho-image-with-text.css: {}
+  dependencies:
+    - common_design_subtheme/gho-aside
+    - common_design_subtheme/gho-caption
+
 gho-photo-gallery:
   css:
     theme:
       components/gho-photo-gallery/gho-photo-gallery.css: {}
+  dependencies:
+    - common_design_subtheme/gho-aside
 
 gho-facts-and-figures:
   css:

--- a/html/themes/custom/common_design_subtheme/components/gho-image-with-text/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-image-with-text/README.md
@@ -1,0 +1,5 @@
+HPC Content Module - Image with text Component
+======================================================
+
+Styling for the image with text component which holds a single image together
+with credits and text.

--- a/html/themes/custom/common_design_subtheme/components/gho-image-with-text/gho-image-with-text.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-image-with-text/gho-image-with-text.css
@@ -1,0 +1,14 @@
+/**
+ * Base photo gallery.
+ */
+.gho-image-with-text .gho-image-with-text__inner {
+  max-width: var(--reading-width);
+}
+
+/**
+ * Caption below images.
+ */
+.gho-image-with-text__caption {
+  max-width: var(--reading-width);
+  margin-top: 1.25rem;
+}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--image-with-text--default.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--image-with-text--default.html.twig
@@ -1,0 +1,70 @@
+{#
+/**
+ * @file
+ * Theme implementation for an image with text in Facts and figures view mode.
+ *
+ * Overrides paragraphs/templates/paragraph.html.twig.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-image-with-text') }}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'gho-image-with-text',
+    'gho-aside',
+    'content-width',
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+    <div class="gho-image-with-text__inner">
+      {{ content.field_image }}
+      <div class="gho-image-with-text__caption gho-caption gho-caption--formatted">
+        <div class="gho-caption__text">
+          {{ content.field_text }}
+          <span class="gho-caption__credits">{{ content.credits }}</span>
+        </div>
+      </div>
+      {{ content|without(['field_image', 'field_text', 'credits']) }}
+    </div>
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
- HPC-9021: Makes the image with text paragraph type use uncropped images and makes it available on articles
- HPC-9059: Modify image tab on article node forms, change wording and styles
