### PR TITLE
berliner/HPC 9056

### DIFF
--- a/html/modules/custom/ncms_ui/css/node_preview.css
+++ b/html/modules/custom/ncms_ui/css/node_preview.css
@@ -1,5 +1,10 @@
+body.ncms-node-preview #main-content {
+  padding: 0.75rem 0;
+}
 body.ncms-node-preview .node--unpublished {
   background: inherit;
+  margin: 4px;
+  padding: 2rem 0;
 }
 
 body.ncms-node-preview.page-node-type-document {

--- a/html/modules/custom/ncms_ui/ncms_ui.module
+++ b/html/modules/custom/ncms_ui/ncms_ui.module
@@ -528,6 +528,12 @@ function ncms_ui_link_alter(&$variables) {
     $node_revision = !empty($route_params['node_revision']) ? $node_storage->loadRevision($route_params['node_revision']) : NULL;
 
     $title = t('Preview: @title', ['@title' => $variables['text']]);
+    if ($node && $node instanceof ContentBase) {
+      $title = t('Preview: @title (@status)', [
+        '@title' => $node->label(),
+        '@status' => $node->isPublished() ? t('Latest published') : t('Latest draft'),
+      ]);
+    }
     if ($node_revision && $node_revision instanceof ContentBase) {
       $title = t('Preview: #@version (@status) - @date', [
         '@version' => $node_revision->getVersionId(),

--- a/html/modules/custom/ncms_ui/ncms_ui.module
+++ b/html/modules/custom/ncms_ui/ncms_ui.module
@@ -620,6 +620,27 @@ function ncms_ui_views_query_alter(ViewExecutable $view, QueryPluginBase $query)
 }
 
 /**
+ * Implements hook_views_pre_render().
+ *
+ * Hide the "Latest version" column when looking at content that is not in one
+ * of the users content spaces.
+ */
+function ncms_ui_views_pre_render(ViewExecutable $view) {
+  $valid_displays = [
+    'page_articles',
+    'page_documents',
+  ];
+  if ($view->id() != 'content' || !in_array($view->current_display, $valid_displays) || !array_key_exists('latest_version', $view->field)) {
+    return;
+  }
+  /** @var \Drupal\ncms_ui\ContentSpaceManager $content_space_manager */
+  $content_space_manager = \Drupal::service('ncms_ui.content_space.manager');
+  if (!$content_space_manager->userIsInValidContentSpace()) {
+    unset($view->field['latest_version']);
+  }
+}
+
+/**
  * Implements hook_node_access_records().
  */
 function ncms_ui_node_access_records(NodeInterface $node) {

--- a/html/modules/custom/ncms_ui/src/Controller/ViewController.php
+++ b/html/modules/custom/ncms_ui/src/Controller/ViewController.php
@@ -9,6 +9,8 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
+use Drupal\ncms_ui\Entity\Content\ContentBase;
+use Drupal\ncms_ui\Entity\ContentVersionInterface;
 use Drupal\node\Controller\NodeViewController;
 use Drupal\node\NodeInterface;
 
@@ -23,9 +25,17 @@ class ViewController extends NodeViewController {
    * Get the title of the preview.
    */
   public function previewTitle(NodeInterface $node) {
-    return $this->t('Preview: @title', [
-      '@title' => $node->label(),
-    ]);
+    if ($node instanceof ContentVersionInterface) {
+      return $this->t('Preview: @title (@version)', [
+        '@title' => $node->label(),
+        '@version' => $node->getContentStatus() == ContentBase::CONTENT_STATUS_PUBLISHED ? $this->t('Latest published') : $this->t('Latest draft'),
+      ]);
+    }
+    else {
+      return $this->t('Preview: @title', [
+        '@title' => $node->label(),
+      ]);
+    }
   }
 
   /**

--- a/html/modules/custom/ncms_ui/src/Entity/Content/ContentBase.php
+++ b/html/modules/custom/ncms_ui/src/Entity/Content/ContentBase.php
@@ -23,11 +23,6 @@ abstract class ContentBase extends Node implements ContentSpaceAwareInterface, C
   use StringTranslationTrait;
   use ContentSpaceEntityTrait;
 
-  const CONTENT_STATUS_PUBLISHED = 'published';
-  const CONTENT_STATUS_PUBLISHED_WITH_DRAFT = 'published_with_draft';
-  const CONTENT_STATUS_DRAFT = 'draft';
-  const CONTENT_STATUS_DELETED = 'trash';
-
   /**
    * {@inheritdoc}
    */

--- a/html/modules/custom/ncms_ui/src/Entity/ContentVersionInterface.php
+++ b/html/modules/custom/ncms_ui/src/Entity/ContentVersionInterface.php
@@ -9,6 +9,11 @@ use Drupal\node\NodeInterface;
  */
 interface ContentVersionInterface extends NodeInterface {
 
+  const CONTENT_STATUS_PUBLISHED = 'published';
+  const CONTENT_STATUS_PUBLISHED_WITH_DRAFT = 'published_with_draft';
+  const CONTENT_STATUS_DRAFT = 'draft';
+  const CONTENT_STATUS_DELETED = 'trash';
+
   /**
    * Get the version id.
    *
@@ -30,6 +35,14 @@ interface ContentVersionInterface extends NodeInterface {
 
   /**
    * Get the status of the content entity.
+   *
+   * @return string
+   *   The status. See the CONTENT_STATUS_* constants.
+   */
+  public function getContentStatus();
+
+  /**
+   * Get the status label of the content entity.
    *
    * @return \Drupal\Core\StringTranslation\TranslatableMarkup
    *   The status.


### PR DESCRIPTION
- HPC-9056: Add publication info to node preview, show unpublished indicator in preview modal
- HPC-9056: Hide latest version column in backend listing when not in own content space
