### PR TITLE
berliner/HPC 9249

### DIFF
--- a/config/core.entity_view_display.media.infographic.default.yml
+++ b/config/core.entity_view_display.media.infographic.default.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.field.media.infographic.field_content_space
     - field.field.media.infographic.field_media_image
-    - image.style.large
     - media.type.infographic
   module:
     - image
@@ -19,7 +18,7 @@ content:
     label: visually_hidden
     settings:
       image_link: ''
-      image_style: large
+      image_style: ''
       image_loading:
         attribute: lazy
     third_party_settings: {  }

--- a/config/filter.format.filtered_html.yml
+++ b/config/filter.format.filtered_html.yml
@@ -41,6 +41,7 @@ filters:
         thumbnail_small: thumbnail_small
       allowed_media_types:
         image: image
+        infographic: infographic
   filter_html_image_secure:
     id: filter_html_image_secure
     provider: filter

--- a/config/media.type.author.yml
+++ b/config/media.type.author.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 id: author
 label: Author
-description: 'Authorship information of an article with the author image, name and title.'
+description: 'Authorship information of an article with the author image, name and title'
 source: image
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/media.type.image.yml
+++ b/config/media.type.image.yml
@@ -4,7 +4,7 @@ status: true
 dependencies: {  }
 id: image
 label: Image
-description: 'An <em>Image</em> file is a still visual.'
+description: 'An <em>Image</em> to be used as a photo or graphic'
 source: image
 queue_thumbnail_downloads: false
 new_revision: true

--- a/config/media.type.infographic.yml
+++ b/config/media.type.infographic.yml
@@ -4,10 +4,10 @@ status: true
 dependencies: {  }
 id: infographic
 label: Infographic
-description: ''
+description: 'An <em>Image</em> to be used specifically as an infographic'
 source: image
 queue_thumbnail_downloads: false
-new_revision: false
+new_revision: true
 source_configuration:
   source_field: field_media_image
 field_map:

--- a/config/media_library.settings.yml
+++ b/config/media_library.settings.yml
@@ -1,3 +1,3 @@
 _core:
   default_config_hash: _3gQsCnZELUjUUqHk8SSh8bXnx7TZwN95vctAeVJG60
-advanced_ui: false
+advanced_ui: true


### PR DESCRIPTION
- HPC-9249: Don't use image styles for infographics
- HPC-9249: Allow infographis in ckeditor media embed modal, update descriptions, use advanced ui
