### PR TITLE
berliner/HPC 9312

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/gho-achievement/gho-achievement.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-achievement/gho-achievement.css
@@ -10,11 +10,13 @@
 .gho-achievement__icon {
   order: -1;
   height: 3rem;
+  margin-bottom: 1rem;
 }
 
 .gho-achievement__icon img {
   width: auto;
   height: 100%;
+  filter: invert(27%) sepia(9%) saturate(0%) hue-rotate(188deg) brightness(93%) contrast(80%);
 }
 
 .gho-achievement__title {

--- a/html/themes/custom/common_design_subtheme/components/gho-story/gho-story.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-story/gho-story.css
@@ -58,10 +58,10 @@
   position: relative;
 }
 .gho-story .media-caption {
-  padding: 1rem 0 0.5rem 0;
-  margin-bottom: 0.5rem;
-  border-bottom: 1px solid #fff;
+  margin-bottom: 1rem;
+  padding: 1rem 0;
   color: #fff;
+  border-bottom: 1px solid #fff;
   font-size: 0.75rem;
 }
 @media (min-width: 768px) {
@@ -87,6 +87,8 @@
 
 /* Same font-size/line-height as caption. @see gho-caption */
 .gho-story__source {
+  margin-top: 1rem;
+  padding-top: 1rem;
   border-top: 1px solid #d8d8d8;
   font-size: 0.75rem;
   line-height: 1.25rem;


### PR DESCRIPTION
- HPC-9312: Remove faulty footnote links before applying GHO footnote magic
- HPC-9312: Increase the spacing below the line in the story paragraph type caption display
- HPC-9312: Adjust the achievement list paragraph type display to use #4d4d4d as the icon color and increase the bottom margin of the icon
