### PR TITLE
berliner/HPC 9312

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/gho-achievement-list/gho-achievement-list.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-achievement-list/gho-achievement-list.css
@@ -5,6 +5,10 @@
   margin-top: 2rem;
 }
 
+.gho-achievement-list .field__item {
+  width: 100%;
+}
+
 @media (min-width: 504px) {
   .gho-achievement-list .field__item {
     flex: 0 0 calc((100% - 1rem) / 2);

--- a/html/themes/custom/common_design_subtheme/components/gho-story/gho-story.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-story/gho-story.css
@@ -58,8 +58,8 @@
   position: relative;
 }
 .gho-story .media-caption {
-  margin-bottom: 1rem;
-  padding: 1rem 0;
+  margin-bottom: 2rem;
+  padding: 0.5rem 0;
   color: #fff;
   border-bottom: 1px solid #fff;
   font-size: 0.75rem;


### PR DESCRIPTION
- HPC-9312: Remove faulty footnote links before applying GHO footnote magic
- HPC-9312: Increase the spacing below the line in the story paragraph type caption display
- HPC-9312: Adjust the achievement list paragraph type display to use #4d4d4d as the icon color and increase the bottom margin of the icon
- HPC-9312: Make all achievement boxes full width in mobile
- HPC-9312: Adjust the spacing above and below the line in the story paragraph type caption display
