### PR TITLE
fix: Prevent anonymous_login from messing with the ocha_monitoring shared secret based auth.

### DIFF
--- a/config/anonymous_login.settings.yml
+++ b/config/anonymous_login.settings.yml
@@ -1,5 +1,5 @@
 _core:
   default_config_hash: ZKVq7lpyGFQf-SCuj_Ng2yLPD24rKHxz-TzGQxBjLl4
-paths: "*\r\n~user/login\r\n~user/login/*\r\n~ncms\r\n~ncms/login\r\n~media/oembed"
+paths: "*\r\n~user/login\r\n~user/login/*\r\n~ncms\r\n~ncms/login\r\n~media/oembed\r\n~json/health-check-results"
 login_path: /ncms/login
 message: ''


### PR DESCRIPTION
Without this exception, it will always reject access even if the key in the header is valid.

Refs: OPS-10153