### PR TITLE
chore: Use the latest mysql:11 docker image for tests.

### DIFF
--- a/.github/tests/docker-compose.yml
+++ b/.github/tests/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - default
 
   mysql:
-    image: public.ecr.aws/unocha/mysql:11.4
+    image: public.ecr.aws/unocha/mysql:11
     hostname: hpc-content-test-mysql
     container_name: hpc-content-test-mysql
     environment:


### PR DESCRIPTION
This is now MariaDB 11.8.6, which matches RDS dev.

Refs: OPS-12081