### PR TITLE
release versions/v3.9.6

### DIFF
--- a/.github/tests/docker-compose.yml
+++ b/.github/tests/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - default
 
   mysql:
-    image: public.ecr.aws/unocha/mysql:11.4
+    image: public.ecr.aws/unocha/mysql:11
     hostname: hpc-content-test-mysql
     container_name: hpc-content-test-mysql
     environment:

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "drupal/field_group": "^4",
         "drupal/gin": "^4.1",
         "drupal/google_tag": "^2.0",
-        "drupal/graphql": "^4.2",
+        "drupal/graphql": "^5.0",
         "drupal/imageapi_optimize_binaries": "^1.0@alpha",
         "drupal/imagemagick": "^4",
         "drupal/inline_entity_form": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -7118,16 +7118,16 @@
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.16",
+            "version": "v0.3.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "11e7d5f93803a2190b00e145142cb00a33d17ad2"
+                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/11e7d5f93803a2190b00e145142cb00a33d17ad2",
-                "reference": "11e7d5f93803a2190b00e145142cb00a33d17ad2",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/6a82ac19a28b916ae0885828795dbd4c59d9a818",
+                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818",
                 "shasum": ""
             },
             "require": {
@@ -7171,9 +7171,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.16"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.17"
             },
-            "time": "2026-03-23T14:35:33+00:00"
+            "time": "2026-04-20T16:07:33+00:00"
         },
         {
             "name": "lcobucci/jwt",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5be85b60f2d1236cb49e9ef2ec948012",
+    "content-hash": "4611a84a0d05dcae1f4c4c8ee3982e7c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3567,26 +3567,27 @@
         },
         {
             "name": "drupal/graphql",
-            "version": "4.13.0",
+            "version": "5.0.0-beta2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/graphql.git",
-                "reference": "8.x-4.13"
+                "reference": "5.0.0-beta2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/graphql-8.x-4.13.zip",
-                "reference": "8.x-4.13",
-                "shasum": "c0915da84db9446fe83ec3248e611b298c603c9a"
+                "url": "https://ftp.drupal.org/files/projects/graphql-5.0.0-beta2.zip",
+                "reference": "5.0.0-beta2",
+                "shasum": "7fcc2bcf674faf665ae3220d00b1b2caf71fef1b"
             },
             "require": {
-                "drupal/core": "^10.2 || ^11",
+                "drupal/core": "^10.4 || ^11",
                 "drupal/typed_data": "^1.0 || ^2.0",
                 "php": ">=8.1",
-                "webonyx/graphql-php": "^14.8.0"
+                "webonyx/graphql-php": "^15.19.1"
             },
             "require-dev": {
-                "drupal/coder": "^8.3.30",
+                "drupal/coder": "8.3.30",
+                "drupal/entity_reference_revisions": "^1.14",
                 "drupal/node-node": "*",
                 "drupal/redirect": "^1.0",
                 "jangregor/phpstan-prophecy": "^2 || ^1",
@@ -3595,11 +3596,11 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-4.13",
-                    "datestamp": "1757422052",
+                    "version": "5.0.0-beta2",
+                    "datestamp": "1771508323",
                     "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -11794,38 +11795,49 @@
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "14.x-dev",
+            "version": "v15.32.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19"
+                "reference": "e8f77f81dbe5de75551137955dd0fd3f779235cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/d9c2fdebc6aa01d831bc2969da00e8588cffef19",
-                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/e8f77f81dbe5de75551137955dd0fd3f779235cf",
+                "reference": "e8f77f81dbe5de75551137955dd0fd3f779235cf",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": "^7.1 || ^8"
+                "php": "^7.4 || ^8"
             },
             "require-dev": {
-                "amphp/amp": "^2.3",
-                "doctrine/coding-standard": "^6.0",
-                "nyholm/psr7": "^1.2",
+                "amphp/amp": "^2.6 || ^3",
+                "amphp/http-server": "^2.1 || ^3",
+                "dms/phpunit-arraysubset-asserts": "dev-master",
+                "ergebnis/composer-normalize": "^2.28",
+                "friendsofphp/php-cs-fixer": "3.95.1",
+                "mll-lab/php-cs-fixer-config": "5.13.0",
+                "nyholm/psr7": "^1.5",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "0.12.82",
-                "phpstan/phpstan-phpunit": "0.12.18",
-                "phpstan/phpstan-strict-rules": "0.12.9",
-                "phpunit/phpunit": "^7.2 || ^8.5",
-                "psr/http-message": "^1.0",
-                "react/promise": "2.*",
-                "simpod/php-coveralls-mirror": "^3.0"
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "2.1.46",
+                "phpstan/phpstan-phpunit": "2.0.16",
+                "phpstan/phpstan-strict-rules": "2.0.10",
+                "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
+                "psr/http-message": "^1 || ^2",
+                "react/http": "^1.6",
+                "react/promise": "^2.0 || ^3.0",
+                "rector/rector": "^2.0",
+                "symfony/polyfill-php81": "^1.23",
+                "symfony/var-exporter": "^5 || ^6 || ^7 || ^8",
+                "thecodingmachine/safe": "^1.3 || ^2 || ^3",
+                "ticketswap/phpstan-error-formatter": "1.3.0"
             },
             "suggest": {
+                "amphp/amp": "To leverage async resolving on AMPHP platform (v3 with AmpFutureAdapter, v2 with AmpPromiseAdapter)",
+                "amphp/http-server": "To leverage async resolving with webserver on AMPHP platform",
                 "psr/http-message": "To use standard GraphQL server",
                 "react/promise": "To leverage async resolving on React PHP platform"
             },
@@ -11847,15 +11859,19 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/14.x"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.32.1"
             },
             "funding": [
+                {
+                    "url": "https://github.com/spawnia",
+                    "type": "github"
+                },
                 {
                     "url": "https://opencollective.com/webonyx-graphql-php",
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-07-05T14:23:37+00:00"
+            "time": "2026-04-21T09:42:39+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -18,6 +18,9 @@
         "drupal/entity_reference_revisions": {
             "Issue #2799479: Views doesn't recognize relationship to host": "patches/entity_reference_revisions-relationship_host_id-2799479-176.patch"
         },
+        "drupal/graphql": {
+          "Issue #3561746: type error on drush updb": "https://www.drupal.org/files/issues/2025-12-05/graphql-3561746-2.patch"
+        },
         "drupal/openid_connect": {
             "Handle case if user is in blocked state after SSO Authorization": "./patches/openid_connect-3390668-6.patch",
             "Incorrect context in hook_redirect_logout_alter": "./patches/openid_connect-3577436-191.patch"

--- a/config/graphql.graphql_servers.ncms.yml
+++ b/config/graphql.graphql_servers.ncms.yml
@@ -10,8 +10,8 @@ schema: ncms_schema
 caching: true
 batching: true
 disable_introspection: false
-query_depth: null
-query_complexity: null
+query_depth: 0
+query_complexity: 0
 schema_configuration:
   ncms_schema:
     extensions:

--- a/patches.lock.json
+++ b/patches.lock.json
@@ -1,5 +1,5 @@
 {
-    "_hash": "e245dd16b2f3bfb5eee10c59a6b068d4c0d5da5b00eb3122df1d3b84c9a8c4e8",
+    "_hash": "c33dc1b9d9dc6752ff34d8940e5a93723fb7c34f5816d833122d8395aef413bc",
     "patches": {
         "drupal/anonymous_login": [
             {
@@ -103,6 +103,18 @@
                 "description": "Issue #2799479: Views doesn't recognize relationship to host",
                 "url": "patches/entity_reference_revisions-relationship_host_id-2799479-176.patch",
                 "sha256": "1d41186b45f839db2728ec93cd48a61ec7473cae119d00f71a31a9d463cba44a",
+                "depth": 1,
+                "extra": {
+                    "provenance": "patches-file:composer.patches.json"
+                }
+            }
+        ],
+        "drupal/graphql": [
+            {
+                "package": "drupal/graphql",
+                "description": "Issue #3561746: type error on drush updb",
+                "url": "https://www.drupal.org/files/issues/2025-12-05/graphql-3561746-2.patch",
+                "sha256": "5ade2d4b1e259785a023ec779e1bd4ab1281df1983e14f1f5e49875dc7e19919",
                 "depth": 1,
                 "extra": {
                     "provenance": "patches-file:composer.patches.json"


### PR DESCRIPTION
- **HPC-10382: Update drupal/graphql 4.x to 5.x, add patch to prevent fatal error during deployment**
- **chore: Use the latest mysql:11 docker image for tests.**
- **chore: Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages.**
